### PR TITLE
Changed function comments to JSDoc

### DIFF
--- a/stimuli.js
+++ b/stimuli.js
@@ -38,18 +38,27 @@ const test_items = [
     //{group_name: groups[1], table: list_group2}
 ];
 
-// Get the list of practice items
-//
-// returns json object with a group and a table, the group will always indicate
-// "practice" since it are the practice items
+
+/**
+ * Get the list of practice items
+ *
+ * Returns an object with a group and a table, the group will always indicate
+ * "practice" since it are the practice items
+ *
+ * @returns {object} object with group and table fields
+ */
 function get_practice_items() {
     return {group_name: "practice", table: practice_items};
 }
 
-// this function will pick a random group from the test_items array.
-//
-// returns json object with a group and a table, the group will always indicate
-// wich list has been chosen for the participant.
+/**
+ * This function will pick a random group from the test_items array.
+ *
+ * Returns an object with a group and a table, the group will always indicate
+ * which list has been chosen for the participant.
+ *
+ * @returns {object} object with group and table fields
+ */
 function pick_random_group() {
     let range = function (n) {
         let empty_array = []


### PR DESCRIPTION
This PR changes the comments above the functions in stimuli.js to the JSDoc format.

Also, I changed the 'returns json object' to 'returns an object', as while ``json object == object``, ``object !== json object``. (Read, they are not reflective. json object can be seen as a subset of the full object spec). The objects defined in stimuli.js do not qualify as JSON objects. (I admit, this is semantics). 

In addition, I have two remarks:
* ``pick_random_group`` is misleadingly worded, as it does more than only pick the group. As the code should be readable by students, I think we should be more descriptive.  (Or split the function in two). 
* We might want to create a named object for the group/table object, instead of the anonymous object it is now. This would allow a linter to figure out when we are accessing stuff that doesn't exist in an object. 